### PR TITLE
Fix join an unjoinable thread in rpc client.

### DIFF
--- a/include/rest_rpc/rpc_client.hpp
+++ b/include/rest_rpc/rpc_client.hpp
@@ -103,7 +103,9 @@ namespace rest_rpc {
 		}
 
 		void run(){
-            thd_->join();
+		    if (thd_ != nullptr && thd_->joinable()) {
+                thd_->join();
+            }
 		}
 
 		void set_connect_timeout(size_t milliseconds) {
@@ -329,7 +331,9 @@ namespace rest_rpc {
 		void stop() {
 			if (thd_ != nullptr) {
 				ios_.stop();
-				thd_->join();
+				if (thd_->joinable()) {
+                    thd_->join();
+                }
 				thd_ = nullptr;
 			}
 		}


### PR DESCRIPTION
The `thd_` in rpc_client.hpp will be joined twice, which might introduce the following exception:

```bash
libc++abi.dylib: terminating with uncaught exception of type std::__1::system_error:
      recursive_mutex lock failed: Invalid argument
```