### PR TITLE
fix issue #42

### DIFF
--- a/include/rest_rpc/connection.h
+++ b/include/rest_rpc/connection.h
@@ -19,7 +19,7 @@ namespace rest_rpc {
             std::string key_file;
         };
 
-		class connection : public std::enable_shared_from_this<connection>, private asio::noncopyable {
+		class connection : public std::enable_shared_from_this<connection>, private boost::asio::noncopyable {
 		public:
 			connection(boost::asio::io_service& io_service, std::size_t timeout_seconds, router& router)
 				: socket_(io_service),
@@ -356,7 +356,7 @@ namespace rest_rpc {
 			uint32_t write_size_ = 0;
 			std::mutex write_mtx_;
 
-			asio::steady_timer timer_;
+			boost::asio::steady_timer timer_;
 			std::size_t timeout_seconds_;
 			int64_t conn_id_ = 0;
 			bool has_closed_;

--- a/include/rest_rpc/io_service_pool.h
+++ b/include/rest_rpc/io_service_pool.h
@@ -7,7 +7,7 @@
 
 namespace rest_rpc {
 namespace rpc_service {
-class io_service_pool : private asio::noncopyable {
+class io_service_pool : private boost::asio::noncopyable {
  public:
   explicit io_service_pool(std::size_t pool_size) : next_io_service_(0) {
     if (pool_size == 0) throw std::runtime_error("io_service_pool size is 0");

--- a/include/rest_rpc/router.h
+++ b/include/rest_rpc/router.h
@@ -13,7 +13,7 @@ namespace rest_rpc {
 	namespace rpc_service {
 		class connection;
 
-		class router : asio::noncopyable {
+		class router : boost::asio::noncopyable {
 		public:
 			template<ExecMode model, typename Function>
 			void register_handler(std::string const& name, Function f) {

--- a/include/rest_rpc/rpc_client.hpp
+++ b/include/rest_rpc/rpc_client.hpp
@@ -51,7 +51,7 @@ const constexpr auto FUTURE = CallModel::future;
 
 const constexpr size_t DEFAULT_TIMEOUT = 5000; // milliseconds
 
-class rpc_client : private asio::noncopyable {
+class rpc_client : private boost::asio::noncopyable {
 public:
   rpc_client()
       : socket_(ios_), work_(ios_), deadline_(ios_), body_(INIT_BUF_SIZE) {
@@ -518,7 +518,7 @@ private:
               // LOG(INFO) << "invalid body len";
               close();
               error_callback(
-                  asio::error::make_error_code(asio::error::message_size));
+                  boost::asio::error::make_error_code(boost::asio::error::message_size));
               return;
             }
           } else {
@@ -536,7 +536,7 @@ private:
       if (!socket_.is_open()) {
         // LOG(INFO) << "socket already closed";
         call_back(req_id,
-                  asio::error::make_error_code(asio::error::connection_aborted),
+            boost::asio::error::make_error_code(boost::asio::error::connection_aborted),
                   {});
         return;
       }
@@ -550,7 +550,7 @@ private:
         } else {
           close();
           error_callback(
-              asio::error::make_error_code(asio::error::invalid_argument));
+              boost::asio::error::make_error_code(boost::asio::error::invalid_argument));
           return;
         }
 
@@ -603,7 +603,7 @@ private:
           cl->cancel();
           cl->callback(ec, data);
         } else {
-          cl->callback(asio::error::make_error_code(asio::error::timed_out),
+          cl->callback(boost::asio::error::make_error_code(boost::asio::error::timed_out),
                        {});
         }
 
@@ -644,7 +644,7 @@ private:
       it->second(data);
     } catch (const std::exception & /*ex*/) {
       error_callback(
-          asio::error::make_error_code(asio::error::invalid_argument));
+          boost::asio::error::make_error_code(boost::asio::error::invalid_argument));
     }
   }
 
@@ -673,10 +673,10 @@ private:
     }
   }
 
-  class call_t : asio::noncopyable,
+  class call_t : boost::asio::noncopyable,
                  public std::enable_shared_from_this<call_t> {
   public:
-    call_t(asio::io_service &ios,
+    call_t(boost::asio::io_service &ios,
            std::function<void(boost::system::error_code, string_view)> cb,
            size_t timeout)
         : timer_(ios), cb_(std::move(cb)), timeout_(timeout) {}
@@ -820,7 +820,7 @@ private:
   }
 
   boost::asio::io_service ios_;
-  asio::ip::tcp::socket socket_;
+  boost::asio::ip::tcp::socket socket_;
 #ifdef CINATRA_ENABLE_SSL
   std::unique_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket &>>
       ssl_stream_;
@@ -838,7 +838,7 @@ private:
   std::condition_variable conn_cond_;
   bool has_wait_ = false;
 
-  asio::steady_timer deadline_;
+  boost::asio::steady_timer deadline_;
 
   struct client_message_type {
     std::uint64_t req_id;

--- a/include/rest_rpc/rpc_server.h
+++ b/include/rest_rpc/rpc_server.h
@@ -13,7 +13,7 @@ using boost::asio::ip::tcp;
 namespace rest_rpc {
 	namespace rpc_service {        
 		using rpc_conn = std::weak_ptr<connection>;
-		class rpc_server : private asio::noncopyable {
+		class rpc_server : private boost::asio::noncopyable {
 		public:
 			rpc_server(unsigned short port, size_t size, size_t timeout_seconds = 15, size_t check_seconds = 10)
 				: io_service_pool_(size),

--- a/include/rest_rpc/use_asio.hpp
+++ b/include/rest_rpc/use_asio.hpp
@@ -25,7 +25,7 @@ namespace boost
 #include <boost/asio/ssl.hpp>
 #endif
 #include <boost/asio/steady_timer.hpp>
-using namespace boost;
+//using namespace boost;
 using tcp_socket = boost::asio::ip::tcp::socket;
 #ifdef CINATRA_ENABLE_SSL
 using ssl_socket = boost::asio::ssl::stream<boost::asio::ip::tcp::socket>;


### PR DESCRIPTION
解决include/rest_rpc/use_asio.hpp中直接使用using namespace boost;导致的命名空间污染。