### PR TITLE
do not export namespace in header file

### DIFF
--- a/include/rest_rpc/rpc_client.hpp
+++ b/include/rest_rpc/rpc_client.hpp
@@ -424,7 +424,7 @@ private:
     deadline_.async_wait([this, timeout](const asio::error_code &ec) {
       if (!ec) {
         if (has_connected_) {
-          write(0, request_type::req_res, buffer_type(0), 0);
+          write(0, request_type::req_res, rpc_service::buffer_type(0), 0);
         }
       }
 
@@ -432,7 +432,7 @@ private:
     });
   }
 
-  void write(std::uint64_t req_id, request_type type, buffer_type &&message,
+  void write(std::uint64_t req_id, request_type type, rpc_service::buffer_type &&message,
              uint32_t func_id) {
     size_t size = message.size();
     assert(size < MAX_BUF_LEN);


### PR DESCRIPTION
不要在头文件中导出命令空间